### PR TITLE
Fix distillery inserting into output slot

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,5 +3,5 @@
 dependencies {
 	devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev')
 
-	api('curse.maven:witchery-69673:2234410')
+	api(deobfCurse('witchery-69673:2234410'))
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-	devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.5.23-GTNH:dev')
+	devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev')
 
 	api('curse.maven:witchery-69673:2234410')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -86,7 +86,7 @@ accessTransformersFile =
 usesMixins = true
 
 # Adds some debug arguments like verbose output and class export.
-usesMixinDebug = false
+usesMixinDebug = true
 
 # Specify the location of your implementation of IMixinConfigPlugin. Leave it empty otherwise.
 mixinPlugin =

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.16'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.19'
 }
 
 

--- a/src/main/java/alkalus/main/core/util/WitchesOvenUtils.java
+++ b/src/main/java/alkalus/main/core/util/WitchesOvenUtils.java
@@ -206,7 +206,7 @@ public class WitchesOvenUtils {
             final int result = getOutputSlot(aTile).stackSize + itemstack.stackSize;
 
             // return result <= aTile.getInventoryStackLimit() && result <= itemstack.getMaxStackSize();
-            return result <= aTile.func_70297_j_() && result <= itemstack.getMaxStackSize();
+            return result <= aTile.getInventoryStackLimit() && result <= itemstack.getMaxStackSize();
         }
     }
 

--- a/src/main/java/alkalus/main/core/util/WitchesOvenUtils.java
+++ b/src/main/java/alkalus/main/core/util/WitchesOvenUtils.java
@@ -205,7 +205,6 @@ public class WitchesOvenUtils {
             }
             final int result = getOutputSlot(aTile).stackSize + itemstack.stackSize;
 
-            // return result <= aTile.getInventoryStackLimit() && result <= itemstack.getMaxStackSize();
             return result <= aTile.getInventoryStackLimit() && result <= itemstack.getMaxStackSize();
         }
     }

--- a/src/main/java/alkalus/main/mixinplugin/Mixin.java
+++ b/src/main/java/alkalus/main/mixinplugin/Mixin.java
@@ -10,7 +10,8 @@ public enum Mixin {
 
     TileEntitySpinningWheelMixin("witchery.TileEntitySpinningWheelMixin", Side.BOTH, TargetedMod.WITCHERY),
     SpinningRecipeMixin("witchery.SpinningRecipeMixin", Side.BOTH, TargetedMod.WITCHERY),
-    ShockwaveTaskMixin("witchery.ShockwaveTaskMixin", Side.BOTH, TargetedMod.WITCHERY);
+    ShockwaveTaskMixin("witchery.ShockwaveTaskMixin", Side.BOTH, TargetedMod.WITCHERY),
+    TileEntityDistilleryMixin("witchery.TileEntityDistilleryMixin", Side.BOTH, TargetedMod.WITCHERY);
 
     public final String mixinClass;
     public final List<TargetedMod> targetedMods;

--- a/src/main/java/alkalus/main/mixins/witchery/TileEntityDistilleryMixin.java
+++ b/src/main/java/alkalus/main/mixins/witchery/TileEntityDistilleryMixin.java
@@ -1,0 +1,16 @@
+package alkalus.main.mixins.witchery;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import com.emoniph.witchery.blocks.BlockDistillery;
+
+@Mixin(BlockDistillery.TileEntityDistillery.class)
+public class TileEntityDistilleryMixin {
+
+    @ModifyConstant(method = "isItemValidForSlot", constant = @Constant(intValue = 3), remap = false)
+    private int witcheryextras$(int original) {
+        return 2;
+    }
+}

--- a/src/main/java/alkalus/main/mixins/witchery/TileEntityDistilleryMixin.java
+++ b/src/main/java/alkalus/main/mixins/witchery/TileEntityDistilleryMixin.java
@@ -10,7 +10,7 @@ import com.emoniph.witchery.blocks.BlockDistillery;
 public class TileEntityDistilleryMixin {
 
     @ModifyConstant(method = "isItemValidForSlot", constant = @Constant(intValue = 3), remap = false)
-    private int witcheryextras$(int original) {
+    private int witcheryextras$fixSlotInsertion(int original) {
         return 2;
     }
 }


### PR DESCRIPTION
The Distillery has 7 slots where slot 0, 1, 2 are the inputs and 3,4,5,6 are the outputs. 
At the moment in isItemValidForSlot is only returning false if the slot is > 3 thus allowing insertion into the first output slot. This simply changes that 3 into a 2.

Closes https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/129